### PR TITLE
[TASK] Stop building with the lowest Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 install:
 - >
-  composer require typo3/minimal:"$TYPO3" $DEPENDENCIES_PREFERENCE;
+  composer require typo3/minimal:"$TYPO3";
   composer show;
 - >
   echo;
@@ -54,15 +54,6 @@ jobs:
   - stage: test
     php: "7.0"
     env: TYPO3=^8.7
-  - stage: test
-    php: "7.2"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
-    php: "7.1"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
-    php: "7.0"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
   - stage: release to ter
     if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
     php: "7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Stop building with the lowest Composer dependencies (#18)
 - Drop the TYPO3 package repository from composer.json (#16)
 
 ### Fixed


### PR DESCRIPTION
This has been too much of a hassle due to breakage caused by old
dev dependencies.